### PR TITLE
Render attribution text using innerHTML property.

### DIFF
--- a/src/SlippyMap/Control/Attribution.elm
+++ b/src/SlippyMap/Control/Attribution.elm
@@ -7,6 +7,8 @@ module SlippyMap.Control.Attribution exposing (control)
 -}
 
 import Html exposing (Html)
+import Html.Attributes
+import Json.Encode
 import SlippyMap.Config as Config
 import SlippyMap.Layer exposing (Layer)
 import SlippyMap.Layer.Control as Control
@@ -27,5 +29,4 @@ render attributions map =
                 |> Maybe.map (\p -> p ++ " | ")
                 |> Maybe.withDefault ""
     in
-    Html.div []
-        [ Html.text (prefixText ++ String.join ", " attributions) ]
+    Html.div [ Html.Attributes.property "innerHTML" <| Json.Encode.string <| prefixText ++ String.join ", " attributions ] []


### PR DESCRIPTION
This makes it possible to use attributions that have links in them.

I considered whether attributes should be `Html msg` instead of `String`, but it seems like tile sources are often accompanied by a snippet of HTML for you to copy-paste. On the other hand, this approach doesn't really allow you to style the attribution, so maybe `Html msg` is the way to go.